### PR TITLE
Minor update to remove note from win builder

### DIFF
--- a/R/create_population.R
+++ b/R/create_population.R
@@ -17,6 +17,6 @@ create_population <- function(popsize,      # population size
   # get problem dimension
   prob.dim <- length(probpars$xmax)
   
-  return (matrix(runif(n = popsize * prob.dim), 
+  return (matrix(stats::runif(n = popsize * prob.dim), 
                  nrow = popsize))
 }

--- a/R/recombination_arith.R
+++ b/R/recombination_arith.R
@@ -23,7 +23,7 @@ recombination_arith <- function(X, M, ...) {
   }
   # ==========
   
-  lambda <- matrix(rep(runif(nrow(X)),
+  lambda <- matrix(rep(stats::runif(nrow(X)),
                        ncol(X)),
                    ncol = ncol(X),
                    byrow = FALSE)

--- a/R/recombination_eigen.R
+++ b/R/recombination_eigen.R
@@ -45,7 +45,7 @@ recombination_eigen <- function(X, M, recpars) {
   # ==========
   
   # Calculate eigenvectors of the covariance matrix of X
-  Q <- eigen(cov(X))$vectors
+  Q <- eigen(stats::cov(X))$vectors
 
   # Project vectors in X and M onto basis Q
   Xq <- t(sapply(1:(2*nrow(X)), 

--- a/R/recombination_geo.R
+++ b/R/recombination_geo.R
@@ -51,7 +51,7 @@ recombination_geo <- function(X, M, recpars = list(alpha = 0.5)) {
   M <- 0.25 + 0.5*(M - mins) / (maxs - mins + eps)
   
   if(is.null(recpars$alpha)){ # use a random value for each recombination
-    alpha <- matrix(rep(runif(nrow(X)),
+    alpha <- matrix(rep(stats::runif(nrow(X)),
                         times = ncol(X)),
                     ncol = ncol(X))
   } else{ # use the given (or default) alpha value for all recombinations
@@ -61,7 +61,7 @@ recombination_geo <- function(X, M, recpars = list(alpha = 0.5)) {
   
   # Randomize which parent will use exponent alpha and which will use 
   # (1-alpha)
-  inv.alpha <- as.logical(round(runif(nrow(X))))
+  inv.alpha <- as.logical(round(stats::runif(nrow(X))))
   alpha[inv.alpha, ] <- 1 - alpha[inv.alpha, ]
   
   # Build recombined population and return it to the original range

--- a/R/recombination_lbga.R
+++ b/R/recombination_lbga.R
@@ -67,7 +67,7 @@ recombination_lbga <- function(X, M, ...) {
                                byrow = FALSE)
   
   
-  mr <- matrix(runif(nrow(X) * 16), 
+  mr <- matrix(stats::runif(nrow(X) * 16), 
                ncol = 16) <= 1 / 16
   
   ms <- matrix(rep((2^-(0:15)), 

--- a/R/recombination_npoint.R
+++ b/R/recombination_npoint.R
@@ -88,7 +88,7 @@ recombination_npoint <- function(X, M, recpars = list(N = NULL)) {
   
   # Randomize which population will donate the variables with the lowermost 
   # indexes
-  if (runif(1) < 0.5){ 
+  if (stats::runif(1) < 0.5){ 
     R <- !R
   }
   

--- a/R/recombination_onepoint.R
+++ b/R/recombination_onepoint.R
@@ -74,7 +74,7 @@ recombination_onepoint <- function(X, M, recpars = list(K = NULL)) {
   
   # Randomize which population will donate the variables with the lowermost 
   # indexes
-  if (runif(1) < 0.5){ 
+  if (stats::runif(1) < 0.5){ 
      R <- !R
 	 }
         

--- a/R/recombination_sbx.R
+++ b/R/recombination_sbx.R
@@ -53,7 +53,7 @@ recombination_sbx <- function(X, M, recpars) {
   beta <- S * ((2 * R) ^ mexp) + (!S) * ((2 * (1 - R)) ^ mexp)
   
   # Return recombined population
-  dir  <- sign(0.5 - matrix(rep(runif(nrow(X)),
+  dir  <- sign(0.5 - matrix(rep(stats::runif(nrow(X)),
                                 times = ncol(X)),
                             ncol = ncol(X)))
   return(0.5 * ((1 + dir * beta) * X + (1 - dir * beta) * M ))

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,7 @@
 # Generate an matrix of uniformly distributed values in the interval (0,1) with
 # the same dimension as M
 randM <- function(M) {
-  matrix(runif(prod(dim(M))), 
+  matrix(stats::runif(prod(dim(M))), 
          ncol = ncol(M))
 }
 


### PR DESCRIPTION
added “stats::” in front of all calls to runif and cov
